### PR TITLE
Ensure that the semaphore keeps working when app after lpop of availa…

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -27,7 +27,7 @@ class Redis
     def exists_or_create!
       token = @redis.getset(exists_key, EXISTS_TOKEN)
 
-      if token.nil?
+      if token.nil? || all_tokens.empty?
         create!
       else
         # Previous versions of redis-semaphore did not set `version_key`.

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -143,6 +143,19 @@ describe "redis" do
         expect(semaphore.locked?).to be true
       end
     end
+
+    it "should recover after being killed after lpop of AVAILABLE" do
+      semaphore.lock
+      semaphore.unlock
+
+      expect(semaphore.available_count). to eq(1)
+
+      @redis.lpop(semaphore.send(:available_key))
+
+      semaphore.lock(-1)
+
+      expect(semaphore.locked?).to be true
+    end
   end
 
   describe "semaphore with expiration" do


### PR DESCRIPTION
…ble key

= Problem

You can kill the app in `def lock` just after the lpop of the
available_key

When that happens the semaphore is gone forever. To fix it you have to
manually delete the exists key.

Expirations also don't help as for some reason the exists key get -1 as a ttl

= Solution

The fix is to recreate the keys in redis if there isn't an AVAILABLE or GRABBED key

= Related

https://stackoverflow.com/questions/60269868/redis-semaphore-locks-cant-be-released/